### PR TITLE
fix(cvm): update cert-manager and attestation-service image digests

### DIFF
--- a/cvm/docker-compose.yml
+++ b/cvm/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   # Combined Nginx reverse proxy and Certificate Manager
   nginx-cert-manager:
-    image: ghcr.io/concrete-security/cert-manager@sha256:1af9c4381774484be345eb6bbc6216c8020367e78b06b15c875a7fe5eb63a872
+    image: ghcr.io/concrete-security/cert-manager@sha256:c9df1c648a82760585e997613ea28d214a05363d3e96d575e501c373b90eab50
     container_name: nginx-cert-manager
     ports:
       - "80:80"
@@ -75,7 +75,7 @@ services:
 
   # TDX Attestation service
   attestation-service:
-    image: ghcr.io/concrete-security/attestation-service@sha256:51e52f431cbae53a50b258733283199fcde983a53531f65067da8ac07b5fb7ad
+    image: ghcr.io/concrete-security/attestation-service@sha256:e7f82b46cf749333a911c947db88544aa545c62aaa98297ba7e3b47dc5082340
     container_name: attestation-service
     environment:
       - HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- Update cert-manager and attestation-service image digests to the versions built after merging PR #76 (`ekm_secret_in_tee`)
- The old images lacked TEE-based EKM key derivation, causing the attestation service to crash (502 on `/tdx_quote`) since `EKM_SHARED_SECRET` was removed from compose env vars

## Test plan
- [ ] Verify `deploy-dev-cvm` workflow triggers on merge and deploys successfully
- [ ] Confirm `vllm.concrete-security.com/tdx_quote` returns a valid quote
- [ ] Run `get-tee-policy-values.py vllm.concrete-security.com` to validate attestation