### PR TITLE
fix(cvm): patch vLLM Anthropic stream to keep tool_calls on finish chunk

### DIFF
--- a/cvm/vllm-patch/Dockerfile
+++ b/cvm/vllm-patch/Dockerfile
@@ -4,3 +4,8 @@ COPY harmony-streaming-tool-call-fallback.patch /tmp/
 RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
     && patch -p1 -d "$SITE" < /tmp/harmony-streaming-tool-call-fallback.patch \
     && rm /tmp/harmony-streaming-tool-call-fallback.patch
+
+COPY anthropic-finish-chunk-tool-call.patch /tmp/
+RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
+    && patch -p1 -d "$SITE" < /tmp/anthropic-finish-chunk-tool-call.patch \
+    && rm /tmp/anthropic-finish-chunk-tool-call.patch

--- a/cvm/vllm-patch/anthropic-finish-chunk-tool-call.patch
+++ b/cvm/vllm-patch/anthropic-finish-chunk-tool-call.patch
@@ -1,0 +1,75 @@
+--- a/vllm/entrypoints/anthropic/serving_messages.py
++++ b/vllm/entrypoints/anthropic/serving_messages.py
+@@ -365,11 +365,9 @@
+                             yield wrap_data_with_event(data, "message_delta")
+                             continue
+ 
+-                        if origin_chunk.choices[0].finish_reason is not None:
+-                            finish_reason = origin_chunk.choices[0].finish_reason
+-                            continue
+-
+-                        # content
++                        # content (process before finish_reason: harmony
++                        # tool-call fallback bundles delta.tool_calls with
++                        # finish_reason="tool_calls" in the same chunk)
+                         if origin_chunk.choices[0].delta.content is not None:
+                             if not content_block_started:
+                                 chunk = AnthropicStreamEvent(
+@@ -398,7 +396,8 @@
+                             continue
+ 
+                         # tool calls
+-                        elif len(origin_chunk.choices[0].delta.tool_calls) > 0:
++                        if (origin_chunk.choices[0].delta.tool_calls is not None
++                                and len(origin_chunk.choices[0].delta.tool_calls) > 0):
+                             tool_call = origin_chunk.choices[0].delta.tool_calls[0]
+                             if tool_call.id is not None:
+                                 if content_block_started:
+@@ -431,20 +430,43 @@
+                                 yield wrap_data_with_event(data, "content_block_start")
+                                 content_block_started = True
+ 
+-                            else:
++                                # The harmony fallback emits id AND arguments
++                                # in the same DeltaToolCall. Stream the args as
++                                # an input_json_delta so the tool_use block
++                                # isn't delivered with empty input.
++                                args = (
++                                    tool_call.function.arguments
++                                    if tool_call.function
++                                    else None
++                                )
++                                if args:
++                                    chunk = AnthropicStreamEvent(
++                                        index=content_block_index,
++                                        type="content_block_delta",
++                                        delta=AnthropicDelta(
++                                            type="input_json_delta",
++                                            partial_json=args,
++                                        ),
++                                    )
++                                    data = chunk.model_dump_json(exclude_unset=True)
++                                    yield wrap_data_with_event(data, "content_block_delta")
++
++                            elif tool_call.function is not None:
+                                 chunk = AnthropicStreamEvent(
+                                     index=content_block_index,
+                                     type="content_block_delta",
+                                     delta=AnthropicDelta(
+                                         type="input_json_delta",
+-                                        partial_json=tool_call.function.arguments
+-                                        if tool_call.function
+-                                        else None,
++                                        partial_json=tool_call.function.arguments,
+                                     ),
+                                 )
+                                 data = chunk.model_dump_json(exclude_unset=True)
+                                 yield wrap_data_with_event(data, "content_block_delta")
+                             continue
++
++                        if origin_chunk.choices[0].finish_reason is not None:
++                            finish_reason = origin_chunk.choices[0].finish_reason
++                            continue
+                 else:
+                     error_response = AnthropicStreamEvent(
+                         type="error",


### PR DESCRIPTION
## Summary
- The Anthropic endpoint's `message_stream_converter` in `serving_messages.py` `continue`s past any chunk that has `finish_reason` set, which silently drops `delta.tool_calls` when they ride along in the same chunk.
- The existing `harmony-streaming-tool-call-fallback.patch` recovers lost tool calls on the OpenAI `serving_chat` path by attaching them to the *finish* chunk — which is exactly the chunk the Anthropic converter was discarding. Net effect: `/v1/messages` responses ended with `stop_reason="tool_use"` and zero `tool_use` content blocks, and Anthropic-compatible clients treat that as a malformed tool call.
- This patch reorders the converter so tool_calls (and content) are emitted before `finish_reason` is recorded, and additionally streams the `input_json_delta` when a single `DeltaToolCall` carries both `id` and `function.arguments` (which is what the harmony fallback emits).

## Why this matters
- Before: running Claude Code against `vllm.concrete-security.com` from the `umbra/` project, a plain "Implement a proxy to vllm that will store everything to logs" prompt hit the bug on **16 of 16 tool-calling turns** in one session. The user-visible error was `The model's tool call could not be parsed (retry also failed).`
- Root-caused by decompiling the `claude` binary: the trigger is `stop_reason === "tool_use" && toolUses.length === 0`. Corroborated by vLLM upstream issues #25560, #23905, #22578 and the note in v0.13.0's `AnthropicServingMessages.message_stream_converter`.
- Short-circuit via a client-side proxy works but doubles round-trips on every tool call (it has to re-query `/v1/chat/completions` to recover). Fixing it server-side is the clean solution.

## Files
- `cvm/vllm-patch/anthropic-finish-chunk-tool-call.patch` — new, targets `vllm/entrypoints/anthropic/serving_messages.py` at v0.13.0. Applies cleanly with `patch -p1`.
- `cvm/vllm-patch/Dockerfile` — applies the new patch after the existing harmony fallback patch (order matters: the harmony fix is what puts tool_calls on the finish chunk; this fix is what stops the Anthropic converter from dropping them).

## Test plan
- [ ] Build the image via the `vLLM Patched Image` workflow (PR triggers build-only, not push).
- [ ] Deploy the built image to staging and point `vllm.concrete-security.com` at it (or a staging equivalent).
- [ ] Reproduce the original failure case: from `umbra/`, run `ANTHROPIC_BASE_URL=https://<staging> ... claude -p "Implement a proxy to vllm that will store everything to logs"`. Expectation: session runs to completion with zero `The model's tool call could not be parsed` errors.
- [ ] Optional: run the detector proxy (local, see notes) with `PROXY_DEBUG=1` in front of staging — it should log zero `BUG detected` events post-deploy. Same proxy logged 16 events on the same prompt against production today.
- [ ] Verify `test_cvm.py` still passes against the new image (the existing suite doesn't cover tool-use specifically, but it should at least not regress).

## Notes for merge
- Commits on this branch are **unsigned** — I pushed from a sandbox without GPG/SSH signing. The `commit-compliance` check will fail on "Check commit signatures". Please resign locally (or amend with a signed commit) before merging.
- Upstream candidate: vLLM main should also pick up this fix; happy to send a patch there once we confirm the behavior on our image.