### PR TITLE
fix(cvm): patch vLLM messages stream to preserve tool_calls on finish chunk

### DIFF
--- a/cvm/vllm-patch/Dockerfile
+++ b/cvm/vllm-patch/Dockerfile
@@ -4,3 +4,8 @@ COPY harmony-streaming-tool-call-fallback.patch /tmp/
 RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
     && patch -p1 -d "$SITE" < /tmp/harmony-streaming-tool-call-fallback.patch \
     && rm /tmp/harmony-streaming-tool-call-fallback.patch
+
+COPY messages-tool-call-on-finish.patch /tmp/
+RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
+    && patch -p1 -d "$SITE" < /tmp/messages-tool-call-on-finish.patch \
+    && rm /tmp/messages-tool-call-on-finish.patch

--- a/cvm/vllm-patch/messages-tool-call-on-finish.patch
+++ b/cvm/vllm-patch/messages-tool-call-on-finish.patch
@@ -1,0 +1,75 @@
+--- a/vllm/entrypoints/anthropic/serving_messages.py
++++ b/vllm/entrypoints/anthropic/serving_messages.py
+@@ -365,11 +365,9 @@
+                             yield wrap_data_with_event(data, "message_delta")
+                             continue
+ 
+-                        if origin_chunk.choices[0].finish_reason is not None:
+-                            finish_reason = origin_chunk.choices[0].finish_reason
+-                            continue
+-
+-                        # content
++                        # content (process before finish_reason: harmony
++                        # tool-call fallback bundles delta.tool_calls with
++                        # finish_reason="tool_calls" in the same chunk)
+                         if origin_chunk.choices[0].delta.content is not None:
+                             if not content_block_started:
+                                 chunk = AnthropicStreamEvent(
+@@ -398,7 +396,8 @@
+                             continue
+ 
+                         # tool calls
+-                        elif len(origin_chunk.choices[0].delta.tool_calls) > 0:
++                        if (origin_chunk.choices[0].delta.tool_calls is not None
++                                and len(origin_chunk.choices[0].delta.tool_calls) > 0):
+                             tool_call = origin_chunk.choices[0].delta.tool_calls[0]
+                             if tool_call.id is not None:
+                                 if content_block_started:
+@@ -431,20 +430,43 @@
+                                 yield wrap_data_with_event(data, "content_block_start")
+                                 content_block_started = True
+ 
+-                            else:
++                                # The harmony fallback emits id AND arguments
++                                # in the same DeltaToolCall. Stream the args as
++                                # an input_json_delta so the tool_use block
++                                # isn't delivered with empty input.
++                                args = (
++                                    tool_call.function.arguments
++                                    if tool_call.function
++                                    else None
++                                )
++                                if args:
++                                    chunk = AnthropicStreamEvent(
++                                        index=content_block_index,
++                                        type="content_block_delta",
++                                        delta=AnthropicDelta(
++                                            type="input_json_delta",
++                                            partial_json=args,
++                                        ),
++                                    )
++                                    data = chunk.model_dump_json(exclude_unset=True)
++                                    yield wrap_data_with_event(data, "content_block_delta")
++
++                            elif tool_call.function is not None:
+                                 chunk = AnthropicStreamEvent(
+                                     index=content_block_index,
+                                     type="content_block_delta",
+                                     delta=AnthropicDelta(
+                                         type="input_json_delta",
+-                                        partial_json=tool_call.function.arguments
+-                                        if tool_call.function
+-                                        else None,
++                                        partial_json=tool_call.function.arguments,
+                                     ),
+                                 )
+                                 data = chunk.model_dump_json(exclude_unset=True)
+                                 yield wrap_data_with_event(data, "content_block_delta")
+                             continue
++
++                        if origin_chunk.choices[0].finish_reason is not None:
++                            finish_reason = origin_chunk.choices[0].finish_reason
++                            continue
+                 else:
+                     error_response = AnthropicStreamEvent(
+                         type="error",


### PR DESCRIPTION
## What's broken
vLLM's `/v1/messages` stream sometimes ends with `stop_reason="tool_use"` but **no `tool_use` block**. Any Messages-API client (Claude Code, the Anthropic SDK, etc.) treats this as a malformed tool call and aborts with *"tool call could not be parsed (retry also failed)"*.

## Why
In `serving_messages.py`, when the stream converter sees a chunk with `finish_reason` set, it `continue`s — silently dropping any `delta.tool_calls` riding along in the same chunk. The existing harmony fallback patch recovers lost tool calls by attaching them *exactly* to that finish chunk, so they were being recovered on the OpenAI path and then thrown away on the Messages path.

## Fix
Reorder the converter so content and tool_calls are emitted before `finish_reason` is recorded. Also stream the `input_json_delta` when a single delta carries both `id` and `arguments` (which is what the harmony fallback emits).

## Repro
Against prod today: `claude -p "Implement a proxy to vllm that will store everything to logs"` from `umbra/` hit the bug **16 out of 16 tool-calling turns**. With this patch, that should go to zero.

## Files
- `messages-tool-call-on-finish.patch` — new, targets `vllm/entrypoints/anthropic/serving_messages.py`
- `Dockerfile` — applies it after the existing harmony patch (order matters: harmony recovers the call onto the finish chunk, this patch keeps it from being dropped)

## Before merge
Commits are **unsigned** — pushed from a sandbox without signing keys. Please re-sign locally before merge. Supersedes #88.