### PR TITLE
fix(cvm): bump vLLM image to messages-tool-call-on-finish patch

### DIFF
--- a/cvm/docker-compose.yml
+++ b/cvm/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm:
-    image: ghcr.io/concrete-security/vllm-openai@sha256:d6ee07e203f0e43dc6b80b600b972fe1dfc9e0eed7810343a4a1beb7727d5062
+    image: ghcr.io/concrete-security/vllm-openai@sha256:b9277f41aa5227b3a2d476821d012319a1c6f8c88593d9bdc28c65ce30de29fe
     container_name: vllm
     environment:
       - NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
## What
Bump the pinned `vllm-openai` digest in `cvm/docker-compose.yml` to the image built by PR #89.

- Old: `sha256:d6ee07e203f0…` (pre-patch)
- New: `sha256:b9277f41aa52…` (tags: `v0.13.0-harmony-fix`, `sha-d281141`)

## Why
Merging #89 built and pushed the patched image to ghcr.io, but the deploy only runs when `cvm/docker-compose.yml` changes. Right now the running CVM is still on the old (unpatched) image.

## Effect
Merging triggers `deploy-dev-cvm.yml`, which rolls the CVM to the patched image. After the model reloads, the *"tool call could not be parsed"* bug should be gone — re-running the same repro (`claude -p "Implement a proxy to vllm that will store everything to logs"` from `umbra/`) should show 0/N bugs via the detector proxy.
