### PR TITLE
fix(cvm): patch vLLM messages endpoint to accept thinking blocks

### DIFF
--- a/cvm/vllm-patch/Dockerfile
+++ b/cvm/vllm-patch/Dockerfile
@@ -9,3 +9,8 @@ COPY messages-tool-call-on-finish.patch /tmp/
 RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
     && patch -p1 -d "$SITE" < /tmp/messages-tool-call-on-finish.patch \
     && rm /tmp/messages-tool-call-on-finish.patch
+
+COPY messages-accept-thinking-blocks.patch /tmp/
+RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
+    && patch -p1 -d "$SITE" < /tmp/messages-accept-thinking-blocks.patch \
+    && rm /tmp/messages-accept-thinking-blocks.patch

--- a/cvm/vllm-patch/messages-accept-thinking-blocks.patch
+++ b/cvm/vllm-patch/messages-accept-thinking-blocks.patch
@@ -1,0 +1,45 @@
+--- a/vllm/entrypoints/anthropic/protocol.py
++++ b/vllm/entrypoints/anthropic/protocol.py
+@@ -34,7 +34,14 @@
+ class AnthropicContentBlock(BaseModel):
+     """Content block in message"""
+ 
+-    type: Literal["text", "image", "tool_use", "tool_result"]
++    type: Literal[
++        "text",
++        "image",
++        "tool_use",
++        "tool_result",
++        "thinking",
++        "redacted_thinking",
++    ]
+     text: str | None = None
+     # For image content
+     source: dict[str, Any] | None = None
+@@ -44,6 +51,13 @@
+     input: dict[str, Any] | None = None
+     content: str | list[dict[str, Any]] | None = None
+     is_error: bool | None = None
++    # Thinking blocks that clients (Claude Code, Anthropic SDK) replay in
++    # message history. The shim does not feed these to the backend model,
++    # but must accept them on input to avoid 400s on conversation replay.
++    thinking: str | None = None
++    signature: str | None = None
++    # For redacted_thinking blocks (opaque encrypted payload).
++    data: str | None = None
+ 
+ 
+ class AnthropicMessage(BaseModel):
+--- a/vllm/entrypoints/anthropic/serving_messages.py
++++ b/vllm/entrypoints/anthropic/serving_messages.py
+@@ -112,6 +112,10 @@
+                 tool_calls: list[dict[str, Any]] = []
+ 
+                 for block in msg.content:
++                    if block.type in ("thinking", "redacted_thinking"):
++                        # Clients replay thinking blocks in history; backend
++                        # model does not consume them, so drop silently.
++                        continue
+                     if block.type == "text" and block.text:
+                         content_parts.append({"type": "text", "text": block.text})
+                     elif block.type == "image" and block.source:


### PR DESCRIPTION
## What's broken
Claude Code and the Anthropic SDK replay assistant-turn thinking blocks on every subsequent request in a conversation. vLLM's `/v1/messages` shim restricts `AnthropicContentBlock.type` to `text/image/tool_use/tool_result`, so any replay fails Pydantic validation:

```
HTTP 400
Input should be 'text', 'image', 'tool_use' or 'tool_result'
```

Effect: interactive Claude Code sessions against vLLM die after the first thinking-enabled turn.

## Fix
- `protocol.py`: widen the `type` Literal to include `thinking` and `redacted_thinking`; add the `thinking`, `signature`, and `data` optional fields clients populate.
- `serving_messages.py`: skip those blocks in `_convert_anthropic_to_openai_request` — the backend model doesn't consume prior-turn reasoning tokens.

## Repro (before)
```bash
curl https://vllm.concrete-security.com/v1/messages -H 'content-type: application/json' -d '{
  "model":"openai/gpt-oss-120b","max_tokens":100,
  "messages":[
    {"role":"user","content":"hi"},
    {"role":"assistant","content":[
      {"type":"thinking","thinking":"...","signature":"abc"},
      {"type":"text","text":"Hello!"}
    ]},
    {"role":"user","content":"now what?"}
  ]
}'
# -> 400 validation error
```

After this patch + rebuild, the same request returns 200.

## Files
- `cvm/vllm-patch/messages-accept-thinking-blocks.patch` — new, targets `protocol.py` + `serving_messages.py` at v0.13.0.
- `cvm/vllm-patch/Dockerfile` — applies it after the two existing patches.

## Follow-up
Same two-step flow as before: once merged, the main-branch build pushes a new image; a follow-up PR will bump `cvm/docker-compose.yml` to the new digest to trigger the deploy.
